### PR TITLE
Issue #44: Fix the way rtsold gets enabled.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,15 +4,3 @@
   command:
     cmd: "/etc/rc.d/netif restart && sleep 5 && /etc/rc.d/routing restart"
   when: networking_autorestart
-
-- name: Enable rtsold
-  service:
-    name: rtsold
-    state: started
-    enabled: true
-
-- name: Disable rtsold
-  service:
-    name: rtsold
-    state: stopped
-    enabled: false

--- a/tasks/interface.yml
+++ b/tasks/interface.yml
@@ -69,13 +69,16 @@
   set_fact:
     networking_iface_ifconfigv6: "{{ networking_iface_ifconfigv6 }} + [ 'inet6 {{ item.ipv6_address | ipv6 }} prefixlen {{ item.ipv6_prefixlen }}' ]"
   when: (item.ipv6_slaac is not defined or item.ipv6_slaac ) and (item.ipv6_address is defined and item.ipv6_prefixlen is defined)
-  notify: Disable rtsold
 
 - name: Generate fragment for SLAAC on {{ item.iface }}
   set_fact:
     networking_iface_ifconfigv6: "{{ networking_iface_ifconfigv6 }} + [ 'inet6 accept_rtadv' ]"
   when: item.ipv6_slaac is defined and item.ipv6_slaac
-  notify: Enable rtsold
+
+- name: Set flag to enable rtsold
+  set_fact:
+    networking_enable_rtsold: true
+  when: item.ipv6_slaac is defined and item.ipv6_slaac
 
 - name: Roll the ifconfig list into a single line for IPv6 on {{ item.iface }}
   sysrc:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,3 +15,5 @@
 - include_tasks: ipv6_gateway.yml
 - include_tasks: resolvers.yml
   when: networking_resolvers_dhcp is sameas false
+- include_tasks: services.yml
+

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Enable rtsold
+  service:
+    name: rtsold
+    state: started
+    enabled: true
+  when: networking_enable_rtsold


### PR DESCRIPTION
We iterate over interfaces and whenever any interface enables SLAAC, we set networking_enable_rtsold as a fact. This fact gets picked up at the end of the playbook in services.yml where it conditionally triggers the rtsold service.